### PR TITLE
update instructions for running model given change in import method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To install the package:
 
 Once installed, set the configuration for your model run in `config.py`.
 
-Run the model using `uv run renal_capacity_model/main.py`. This runs a full trial.
+Run the model using `uv run -m renal_capacity_model.main`. This runs a full trial.
 
-To run a single model run, use `uv run renal_capacity_model/model.py`
+To run a single model run, use `uv run -m renal_capacity_model.model`
 
 ## Information for developers
 


### PR DESCRIPTION
We need to run renal_capacity_model/model.py and renal_capacity_model/main.py as Python modules not as standalone scripts, following changes to imports in #55 