### PR TITLE
reconfigures event_log to make next allocated modality explicit

### DIFF
--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -10,6 +10,7 @@ from renal_capacity_model.helpers import (
     check_config_duration_valid,
     calculate_lookup_year,
     process_event_log,
+    calculate_model_results,
 )
 import pandas as pd
 from datetime import datetime
@@ -1045,7 +1046,8 @@ class Model:
         for patient_type in self.patient_types:
             self.env.process(self.generator_patient_arrivals(patient_type))
         self.env.run(until=self.config.sim_duration)
-        results_df, activity_change = process_event_log(self.event_log)
+        self.event_log = process_event_log(self.event_log)
+        results_df, activity_change = calculate_model_results(self.event_log)
         self.results_df = results_df
         self.activity_change = activity_change
 


### PR DESCRIPTION
Closes #115 - makes it easier to see patient journeys when they pass through modality_allocation
Also, activity_change reporting now also splits by patient_type and patient_flag (incident/prevalent)

BEFORE: (note that this is dummy data, patient_id is just generated by the model and does not correspond to any real patient journeys)

patient_id | patient_type | activity_from | activity_to | time_starting_activity_from | time in activity_from
-- | -- | -- | -- | -- | -- 
329 | 2_early | ichd | modality_allocation | 0 | 257.6347560452204
329 | 2_early | pd | modality_allocation | 257.6347560452204 | 224.64079570326706
329 | 2_early  | ichd | cadaver | 482.2755517484875 | 451.6074702352014
329 | 2_early  | cadaver | graft_failure_modality_allocation | 933.8830219836889 | 2148.490753388242
329 | 2_early  | waiting_for_transplant | dialysis_modality_allocation | 3082.3737753719306 | 137.07423511332053
329 | 2_early  | pd | modality_allocation | 3219.448010485251 | 1079.954121794619
329 | 2_early  | ichd | cadaver | 4299.402132 | 354.5654819542865
329 | 2_early  | cadaver | death | 4653.967614234156 | 4746

AFTER:
patient_id | patient_type | activity_from | activity_to | time_starting_activity_from | time in activity_from
-- | -- | -- | -- | -- | -- 
329 | 2_early | ichd | pd | 0 | 257.6347560452204
329 | 2_early | pd | ichd | 257.6347560452204 | 224.64079570326706
329 | 2_early  | ichd | cadaver | 482.2755517484875 | 451.6074702352014
329 | 2_early  | cadaver | waiting_for_transplant | 933.8830219836889 | 2148.490753388242
329 | 2_early  | waiting_for_transplant | pd | 3082.3737753719306 | 137.07423511332053
329 | 2_early  | pd | ichd  | 3219.448010485251 | 1079.954121794619
329 | 2_early  | ichd | cadaver | 4299.402132 | 354.5654819542865
329 | 2_early  | cadaver | death | 4653.967614234156 | 4746

There are still quite a few cases where the activity_to is still modality_allocation, this is in situations where the time_on_dialysis_modality or time_living_with_transplant is higher than sim_duration so they never get given a new modality