### PR TITLE
fix to the HHD intervention in the event log

### DIFF
--- a/renal_capacity_model/config.py
+++ b/renal_capacity_model/config.py
@@ -3,18 +3,18 @@ This module contains the configuration for running the model.
 It can be adapted to take inputs from users
 """
 
-from renal_capacity_model.helpers import (
-    get_yearly_arrival_rate,
-    get_mean_iat_over_time_from_arrival_rate,
-)
 from renal_capacity_model.config_values import (
-    national_config_dict,
     load_time_to_event_curves,
+    national_config_dict,
     ttd_con_care_values,
-    tw_before_dialysis_values,
     ttd_krt_values,
+    tw_before_dialysis_values,
     tw_cadTx,
     tw_liveTx,
+)
+from renal_capacity_model.helpers import (
+    get_mean_iat_over_time_from_arrival_rate,
+    get_yearly_arrival_rate,
 )
 from renal_capacity_model.utils import get_logger
 
@@ -47,7 +47,7 @@ class Config:
         self.sim_duration = config_dict.get(
             "sim_duration", int(13 * 365)
         )  # in days, but should be a multiple of 365 i.e. years.
-        self.random_seed = config_dict.get("random_seed", 0)
+        self.random_seed = config_dict.get("random_seed", 0)  ### our base random seed
         self.arrival_rate = config_dict["arrival_rate"]
         # how often to take a snapshot of the results_df
         self.snapshot_interval = config_dict.get("snapshot_interval", int(365))

--- a/renal_capacity_model/helpers.py
+++ b/renal_capacity_model/helpers.py
@@ -2,12 +2,14 @@
 Module with helper functions
 """
 
-from renal_capacity_model.utils import get_logger
-import pandas as pd
-import numpy as np
-from itertools import product
 import math
+from itertools import product
 from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from renal_capacity_model.utils import get_logger
 
 if TYPE_CHECKING:
     from renal_capacity_model.config import Config
@@ -238,7 +240,7 @@ def adjust_next_modality(event_log: pd.DataFrame) -> pd.DataFrame:
 
 
 def process_event_log(event_log: pd.DataFrame) -> pd.DataFrame:
-    """Processes event log for easier validation and debugging
+    """Processes event log for easier validation and debugging. Also removes unnecessary rows that were outdated by the HHD intervention if applied.
 
     Args:
         event_log (pd.DataFrame): event log
@@ -247,6 +249,23 @@ def process_event_log(event_log: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame with additional columns ("year_start", "end_time", "year_end")
         and clearer information on which modality was next
     """
+
+    ## loop through the patient ids and remove any rows where time_starting_activity_from is equal to time_starting_activity from in the row below.
+    for patient_id in event_log["patient_id"].unique():
+        if (
+            event_log.loc[
+                event_log["patient_id"] == patient_id, "time_starting_activity_from"
+            ]
+            .duplicated()
+            .any()
+        ):
+            df = event_log.loc[
+                event_log["patient_id"] == patient_id, "time_starting_activity_from"
+            ]
+            duplicates_mask = df.duplicated(keep=False)
+            duplicate_index = df.index[duplicates_mask].tolist()[0]
+            event_log = event_log.drop(duplicate_index)
+
     event_log["year_start"] = event_log["time_starting_activity_from"].apply(
         calculate_lookup_year
     )

--- a/renal_capacity_model/helpers.py
+++ b/renal_capacity_model/helpers.py
@@ -249,7 +249,6 @@ def process_event_log(event_log: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame with additional columns ("year_start", "end_time", "year_end")
         and clearer information on which modality was next
     """
-
     ## loop through the patient ids and remove any rows where time_starting_activity_from is equal to time_starting_activity from in the row below.
     for patient_id in event_log["patient_id"].unique():
         if (
@@ -265,7 +264,6 @@ def process_event_log(event_log: pd.DataFrame) -> pd.DataFrame:
             duplicates_mask = df.duplicated(keep=False)
             duplicate_index = df.index[duplicates_mask].tolist()[0]
             event_log = event_log.drop(duplicate_index)
-
     event_log["year_start"] = event_log["time_starting_activity_from"].apply(
         calculate_lookup_year
     )

--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -2,25 +2,27 @@
 Module containing the Model class. Contains most of the logic for the simulation.
 """
 
-import simpy
-from renal_capacity_model.entity import Patient
+from typing import Generator
+
 import numpy as np
+import pandas as pd
+import simpy
+
 from renal_capacity_model.config import Config
+from renal_capacity_model.entity import Patient
 from renal_capacity_model.helpers import (
-    check_config_duration_valid,
     calculate_lookup_year,
-    process_event_log,
     calculate_model_results,
-    truncate_2dp,
     calculate_time_to_event,
+    check_config_duration_valid,
+    process_event_log,
+    truncate_2dp,
 )
 from renal_capacity_model.process_outputs import (
     create_results_folder,
     save_result_files,
 )
 from renal_capacity_model.utils import get_logger
-import pandas as pd
-from typing import Generator
 
 logger = get_logger(__name__)
 
@@ -795,6 +797,21 @@ class Model:
                 patient.dialysis_modality = "ichd"
             else:
                 patient.dialysis_modality = "hhd"
+        ## replace "modality_allocation" in the event log with the specific modality allocated to the patient
+        if not self.event_log.loc[self.event_log["patient_id"] == patient.id].empty:
+            if (
+                self.event_log.loc[
+                    self.event_log["patient_id"] == patient.id, "activity_to"
+                ].iloc[-1]
+                == "modality_allocation"
+            ):
+                condition = (self.event_log["patient_id"] == patient.id) & (
+                    self.event_log["activity_to"] == "modality_allocation"
+                )
+                last_index = self.event_log.loc[condition].index.max()
+                self.event_log.loc[last_index, "activity_to"] = (
+                    patient.dialysis_modality
+                )
         try:
             self.processes[patient.id] = self.env.process(
                 self.start_dialysis_modality(patient)
@@ -996,7 +1013,7 @@ class Model:
                 self._update_event_log(
                     patient,
                     "waiting_for_transplant",
-                    "dialysis_modality_allocation",
+                    "modality_allocation",
                     float(self.env.now),
                     event_time,
                 )
@@ -1310,14 +1327,31 @@ class Model:
                     # randomly select patients to move from ichd to hhd
                     for patient in self.patient_objects:
                         if patient.id in patients_to_move:
-                            patient.dialysis_modality = "hhd"
-
                             # pass in the process we want to interrupt
                             # interrupt the current process for the patient as we are changing their modality outside of the normal modality change process
                             self.stop_patient(
                                 process=self.processes[patient.id], patient=patient
                             )
-
+                            ## get rid of the last entry in the log for this patient
+                            # if not self.event_log.loc[
+                            #    self.event_log["patient_id"] == patient.id
+                            # ].empty:
+                            #    if patient.time_starts_dialysis != self.env.now - 364:
+                            # self.event_log = self.event_log.drop(
+                            #    self.event_log.index[
+                            #        (self.event_log["patient_id"] == patient.id)
+                            #    ][-1]
+                            # )
+                            #        pass
+                            ## add new entry in the log for this patient ## we remove the old one at the end of the experiment
+                            self._update_event_log(
+                                patient,
+                                "ichd",
+                                "hhd",
+                                patient.time_starts_dialysis,
+                                float(self.env.now)
+                                - float(patient.time_starts_dialysis),
+                            )
                             patient.time_until_death -= np.float64(
                                 self.env.now
                             ) - np.float64(patient.time_starts_dialysis)
@@ -1328,8 +1362,8 @@ class Model:
                                 patient.remaining_time_on_transplant_list -= np.float64(
                                     self.env.now
                                 ) - np.float64(patient.time_starts_dialysis)
+                            patient.dialysis_modality = "hhd"
                             patient.time_starts_dialysis = self.env.now
-                            # patient.time_on_dialysis = {"ichd": 0.0, "hhd": 0.0, "pd": 0.0}
                             try:
                                 self.processes[patient.id] = self.env.process(
                                     self.start_dialysis_modality(patient)

--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -52,16 +52,40 @@ class Model:
         self.patient_counter: int = 0
         self.run_number = run_number
         self.rng = rng
-        ## new
-        seeds = rng.integers(0, 2**31, size=10)
+
+        # set up the random number streams - we need separate streams for different events so that when we run multiple iterations of the model,
+        # the same patients have the same sequence of events across iterations, allowing for a fair comparison of results across iterations.
+        # We can achieve this by using our base random seed to generate a set of seeds for each event stream, and then using those seeds to create
+        # separate random number generators for each event stream.
+        seeds = rng.integers(0, 2**31, size=100)
+
         self.arrivals_rng = np.random.default_rng(seeds[0])
-        self.interventions_rng = np.random.default_rng(seeds[1])
-        self.deaths_rng = np.random.default_rng(seeds[2])
-        self.waiting_for_live_transplant_rng = np.random.default_rng(seeds[3])
-        self.waiting_for_cadaver_transplant_rng = np.random.default_rng(seeds[4])
-        self.live_graft_failure_rng = np.random.default_rng(seeds[5])
-        self.cadaver_graft_failure_rng = np.random.default_rng(seeds[6])
-        ##
+
+        # routing rng streams
+        self.con_care_rng = np.random.default_rng(seeds[1])
+        self.suitable_for_transplant_rng = np.random.default_rng(seeds[2])
+        self.receives_transplant_rng = np.random.default_rng(seeds[3])
+        self.live_or_cadaver_transplant_rng = np.random.default_rng(seeds[4])
+        self.preemptive_live_transplant_rng = np.random.default_rng(seeds[5])
+        self.preemptive_cadaver_transplant_rng = np.random.default_rng(seeds[6])
+        self.modality_allocation_rng = np.random.default_rng(seeds[7])
+        self.modality_switch_from_ichd_rng = np.random.default_rng(seeds[19])
+        self.modality_switch_from_hhd_rng = np.random.default_rng(seeds[20])
+        self.modality_switch_from_pd_rng = np.random.default_rng(seeds[21])
+        # event time rng streams
+        self.ttd_rng = np.random.default_rng(seeds[8])
+        self.tw_for_live_transplant_rng = np.random.default_rng(seeds[9])
+        self.tw_for_cadaver_transplant_rng = np.random.default_rng(seeds[10])
+        self.ttgf_live_rng = np.random.default_rng(seeds[11])
+        self.ttgf_cadaver_rng = np.random.default_rng(seeds[12])
+        self.ttma_ichd_rng = np.random.default_rng(seeds[13])
+        self.ttma_hhd_rng = np.random.default_rng(seeds[14])
+        self.ttma_pd_rng = np.random.default_rng(seeds[15])
+        self.tw_post_transplant_before_dialysis_rng = np.random.default_rng(seeds[16])
+        self.ttd_con_care_rng = np.random.default_rng(seeds[17])
+        # interventions rng stream
+        self.interventions_rng = np.random.default_rng(seeds[18])
+
         self.patient_types = self.config.mean_iat_over_time_dfs.keys()
         self.patients_in_system: dict = {k: 0 for k in self.patient_types}
         self.patient_objects: list[Patient] = []
@@ -112,7 +136,7 @@ class Model:
                     f"Patient {p.id} of age group {p.age_group} is in conservative care at time {self.env.now}."
                 )
             sampled_con_care_time = calculate_time_to_event(
-                self.rng,
+                self.ttd_con_care_rng,
                 scale=self.config.ttd_con_care["scale"],
                 shape=self.config.ttd_con_care["shape"],
             )
@@ -134,13 +158,13 @@ class Model:
             p.dialysis_modality = "ichd"
             p.time_starts_dialysis = self.env.now
             if (
-                self.rng.uniform(0, 1)
+                self.suitable_for_transplant_rng.uniform(0, 1)
                 > self.config.suitable_for_transplant_dist["prev"][p.age_group]
             ):
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -156,7 +180,7 @@ class Model:
             else:
                 # they are suitable for transplant
                 if (
-                    self.rng.uniform(0, 1)
+                    self.receives_transplant_rng.uniform(0, 1)
                     > self.config.receives_transplant_dist[1]["prev"][p.age_group]
                 ):
                     # they don't receive a transplant in the simulation period
@@ -165,7 +189,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -183,7 +207,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -198,13 +222,13 @@ class Model:
                             f"Patient {p.id} of age group {p.age_group} is in ICHD dialysis whilst waiting for transplant at time {self.env.now}."
                         )
                     if (
-                        self.rng.uniform(0, 1)
+                        self.live_or_cadaver_transplant_rng.uniform(0, 1)
                         < self.config.transplant_type_dist["prev"][p.age_group]
                     ):
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_live_transplant_rng,
+                            self.tw_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -221,7 +245,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_cadaver_transplant_rng,
+                            self.tw_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -245,13 +269,13 @@ class Model:
             p.dialysis_modality = "hhd"
             p.time_starts_dialysis = self.env.now
             if (
-                self.rng.uniform(0, 1)
+                self.suitable_for_transplant_rng.uniform(0, 1)
                 > self.config.suitable_for_transplant_dist["prev"][p.age_group]
             ):
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -267,7 +291,7 @@ class Model:
             else:
                 # they are suitable for transplant
                 if (
-                    self.rng.uniform(0, 1)
+                    self.receives_transplant_rng.uniform(0, 1)
                     > self.config.receives_transplant_dist[1]["prev"][p.age_group]
                 ):
                     # they don't receive a transplant in the simulation period
@@ -276,7 +300,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -294,7 +318,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -309,13 +333,13 @@ class Model:
                             f"Patient {p.id} of age group {p.age_group} is in HHD dialysis whilst waiting for transplant at time {self.env.now}."
                         )
                     if (
-                        self.rng.uniform(0, 1)
+                        self.live_or_cadaver_transplant_rng.uniform(0, 1)
                         < self.config.transplant_type_dist["prev"][p.age_group]
                     ):
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_live_transplant_rng,
+                            self.tw_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -332,7 +356,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_cadaver_transplant_rng,
+                            self.tw_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -355,13 +379,13 @@ class Model:
             p.dialysis_modality = "pd"
             p.time_starts_dialysis = self.env.now
             if (
-                self.rng.uniform(0, 1)
+                self.suitable_for_transplant_rng.uniform(0, 1)
                 > self.config.suitable_for_transplant_dist["prev"][p.age_group]
             ):
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -377,7 +401,7 @@ class Model:
             else:
                 # they are suitable for transplant
                 if (
-                    self.rng.uniform(0, 1)
+                    self.receives_transplant_rng.uniform(0, 1)
                     > self.config.receives_transplant_dist[1]["prev"][p.age_group]
                 ):
                     # they don't receive a transplant in the simulation period
@@ -386,7 +410,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -404,7 +428,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -419,13 +443,13 @@ class Model:
                             f"Patient {p.id} of age group {p.age_group} is in PD dialysis whilst waiting for transplant at time {self.env.now}."
                         )
                     if (
-                        self.rng.uniform(0, 1)
+                        self.live_or_cadaver_transplant_rng.uniform(0, 1)
                         < self.config.transplant_type_dist["prev"][p.age_group]
                     ):
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_live_transplant_rng,
+                            self.tw_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -442,7 +466,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.waiting_for_cadaver_transplant_rng,
+                            self.tw_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -465,7 +489,7 @@ class Model:
             transplant_type = location.split("_")[0]
             p.transplant_suitable = True
             p.time_until_death = calculate_time_to_event(
-                self.deaths_rng,
+                self.ttd_rng,
                 scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                     p.referral_type
                 ][p.age_group]["scale"],
@@ -543,7 +567,10 @@ class Model:
             self.patient_objects.append(p)
 
             year = calculate_lookup_year(self.env.now)
-            if self.rng.uniform(0, 1) > self.config.con_care_dist[year][p.age_group]:
+            if (
+                self.con_care_rng.uniform(0, 1)
+                > self.config.con_care_dist[year][p.age_group]
+            ):
                 # If the patient is not diverted to conservative care they start KRT
                 self.env.process(self.start_krt(p))
             else:
@@ -558,7 +585,9 @@ class Model:
         Yields:
             simpy.Environment.Timeout: Simpy Timeout event with a delay of the sampled inter-arrival time
         """
-        sampled_con_care_time = self.config.ttd_con_care["scale"] * self.rng.weibull(
+        sampled_con_care_time = self.config.ttd_con_care[
+            "scale"
+        ] * self.ttd_con_care_rng.weibull(
             a=self.config.ttd_con_care["shape"], size=None
         )
         self._update_event_log(
@@ -586,14 +615,14 @@ class Model:
         """
         year = calculate_lookup_year(self.env.now)
         if (
-            self.rng.uniform(0, 1)
+            self.suitable_for_transplant_rng.uniform(0, 1)
             > self.config.suitable_for_transplant_dist["inc"][patient.age_group]
         ):
             # Patient is not suitable for transplant and so starts dialysis only pathway
             patient.transplant_suitable = False
             if patient.time_until_death == 0:
                 patient.time_until_death = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["incidence"]["not_listed"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -612,13 +641,13 @@ class Model:
             # Patient is suitable for transplant and so we need to decide if they start pre-emptive transplant or dialysis whilst waiting for transplant
             patient.transplant_suitable = True
             if (
-                self.rng.uniform(0, 1)
+                self.receives_transplant_rng.uniform(0, 1)
                 > self.config.receives_transplant_dist[year]["inc"][patient.age_group]
             ):
                 # Although suitable for transplant, patient does not receive a transplant in the simulation period
                 if patient.time_until_death == 0:
                     patient.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["incidence"]["listed"][
                             patient.referral_type
                         ][patient.age_group]["scale"],
@@ -640,7 +669,7 @@ class Model:
                 # Patient may receive a transplant in the simulation period
                 if patient.time_until_death == 0:
                     patient.time_until_death = calculate_time_to_event(
-                        self.deaths_rng,
+                        self.ttd_rng,
                         scale=self.config.ttd_krt["incidence"]["received_Tx"][
                             patient.referral_type
                         ][patient.age_group]["scale"],
@@ -651,7 +680,7 @@ class Model:
                     )
                 # We now assign a transplant type: live or cadaver as this impacts the probability of starting pre-emptive transplant
                 if (
-                    self.rng.uniform(0, 1)
+                    self.live_or_cadaver_transplant_rng.uniform(0, 1)
                     < self.config.transplant_type_dist["inc"][patient.age_group]
                 ):
                     patient.transplant_type = "live"
@@ -660,7 +689,7 @@ class Model:
 
                 if patient.transplant_type == "live":
                     if (
-                        self.rng.uniform(0, 1)
+                        self.preemptive_live_transplant_rng.uniform(0, 1)
                         < self.config.pre_emptive_transplant_live_donor_dist[year][
                             patient.referral_type
                         ]
@@ -679,7 +708,7 @@ class Model:
                         patient.time_enters_waiting_list = self.env.now
                         patient.remaining_time_on_transplant_list = (
                             calculate_time_to_event(
-                                self.waiting_for_live_transplant_rng,
+                                self.tw_for_live_transplant_rng,
                                 scale=self.config.tw_liveTx["incidence"][
                                     patient.age_group
                                 ]["scale"],
@@ -703,7 +732,7 @@ class Model:
                         )
                 else:  # cadaver
                     if (
-                        self.rng.uniform(0, 1)
+                        self.preemptive_cadaver_transplant_rng.uniform(0, 1)
                         < self.config.pre_emptive_transplant_cadaver_donor_dist[year][
                             patient.referral_type
                         ]
@@ -724,7 +753,7 @@ class Model:
                         patient.time_enters_waiting_list = self.env.now
                         patient.remaining_time_on_transplant_list = (
                             calculate_time_to_event(
-                                self.waiting_for_cadaver_transplant_rng,
+                                self.tw_for_cadaver_transplant_rng,
                                 scale=self.config.tw_cadTx["incidence"][
                                     patient.age_group
                                 ]["scale"],
@@ -766,7 +795,7 @@ class Model:
         modality_allocation_distributions = (
             self.config.modality_allocation_distributions[year]
         )
-        random_number = self.rng.uniform(0, 1)
+        random_number = self.modality_allocation_rng.uniform(0, 1)
         current_modality = patient.dialysis_modality
         if current_modality == "none":
             if (
@@ -785,7 +814,7 @@ class Model:
                 patient.dialysis_modality = "pd"
         elif current_modality == "ichd":
             if (
-                self.rng.uniform(0, 1)
+                self.modality_switch_from_ichd_rng.uniform(0, 1)
                 < modality_allocation_distributions[current_modality]["hhd"]
             ):
                 patient.dialysis_modality = "hhd"
@@ -793,7 +822,7 @@ class Model:
                 patient.dialysis_modality = "pd"
         elif current_modality == "hhd":
             if (
-                self.rng.uniform(0, 1)
+                self.modality_switch_from_hhd_rng.uniform(0, 1)
                 < modality_allocation_distributions[current_modality]["ichd"]
             ):
                 patient.dialysis_modality = "ichd"
@@ -801,7 +830,7 @@ class Model:
                 patient.dialysis_modality = "pd"
         elif current_modality == "pd":
             if (
-                self.rng.uniform(0, 1)
+                self.modality_switch_from_pd_rng.uniform(0, 1)
                 < modality_allocation_distributions[current_modality]["ichd"]
             ):
                 patient.dialysis_modality = "ichd"
@@ -842,9 +871,9 @@ class Model:
         if patient.transplant_count == 0:
             # adjust the time to death as this is a patient that has recieve (not just been listed for) a transplant
             if patient.patient_flag == "incident":
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                # random_number = truncate_2dp(self.rng.uniform(0, 1))
                 sampled_time = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["incidence"]["received_Tx"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -859,9 +888,9 @@ class Model:
                     current_tud,
                 )
             else:  # prevalent patient
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                # random_number = truncate_2dp(self.rng.uniform(0, 1))
                 sampled_time = calculate_time_to_event(
-                    self.deaths_rng,
+                    self.ttd_rng,
                     scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -882,7 +911,7 @@ class Model:
             # how long the graft lasts depends on where they go next: death or back to start_krt
             ## sampled_wait_time depends on whether patient is incident or not
             if patient.patient_flag == "incident":
-                random_number = truncate_2dp(self.live_graft_failure_rng.uniform(0, 1))
+                random_number = truncate_2dp(self.ttgf_live_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx"].loc[
                         random_number, patient.patient_type
@@ -890,7 +919,7 @@ class Model:
                     * self.config.multipliers["ttgf"]["inc"]["live"]
                 )
             else:  # prevalent patient
-                random_number = truncate_2dp(self.live_graft_failure_rng.uniform(0, 1))
+                random_number = truncate_2dp(self.ttgf_live_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx_initialisation"].loc[
                         random_number, patient.patient_type
@@ -899,9 +928,7 @@ class Model:
                 )
         else:  # cadaver
             if patient.patient_flag == "incident":
-                random_number = truncate_2dp(
-                    self.cadaver_graft_failure_rng.uniform(0, 1)
-                )
+                random_number = truncate_2dp(self.ttgf_cadaver_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_cadTx"].loc[
                         random_number, patient.patient_type
@@ -909,9 +936,7 @@ class Model:
                     * self.config.multipliers["ttgf"]["inc"]["cadaver"]
                 )
             else:  # prevalent patient
-                random_number = truncate_2dp(
-                    self.cadaver_graft_failure_rng.uniform(0, 1)
-                )
+                random_number = truncate_2dp(self.ttgf_cadaver_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx_initialisation"].loc[
                         random_number, patient.patient_type
@@ -994,7 +1019,9 @@ class Model:
             # if it is longer than their time on the waiting list they start transplant pre-emptively
             sampled_wait_time = self.config.tw_before_dialysis[
                 "scale"
-            ] * self.rng.weibull(a=self.config.tw_before_dialysis["shape"], size=None)
+            ] * self.tw_post_transplant_before_dialysis_rng.weibull(
+                a=self.config.tw_before_dialysis["shape"], size=None
+            )
 
             next_event = ["start_dialysis", "pre_emptive_transplant", "death"]
             time_to_next_event = [
@@ -1083,7 +1110,12 @@ class Model:
 
         ## sampled_time depends on whether patient is incident or not
         if patient.patient_flag == "incident":
-            random_number = truncate_2dp(self.rng.uniform(0, 1))
+            if patient.dialysis_modality == "ichd":
+                random_number = truncate_2dp(self.ttma_ichd_rng.uniform(0, 1))
+            elif patient.dialysis_modality == "hhd":
+                random_number = truncate_2dp(self.ttma_hhd_rng.uniform(0, 1))
+            else:
+                random_number = truncate_2dp(self.ttma_pd_rng.uniform(0, 1))
             sampled_time = (
                 self.config.time_to_event_curves[
                     f"ttma_{patient.dialysis_modality}"
@@ -1091,7 +1123,12 @@ class Model:
                 * self.config.multipliers["ttma"]["inc"][patient.dialysis_modality]
             )
         else:  ## prevalent patient
-            random_number = truncate_2dp(self.rng.uniform(0, 1))
+            if patient.dialysis_modality == "ichd":
+                random_number = truncate_2dp(self.ttma_ichd_rng.uniform(0, 1))
+            elif patient.dialysis_modality == "hhd":
+                random_number = truncate_2dp(self.ttma_hhd_rng.uniform(0, 1))
+            else:
+                random_number = truncate_2dp(self.ttma_pd_rng.uniform(0, 1))
             sampled_time = (
                 self.config.time_to_event_curves[
                     f"ttma_{patient.dialysis_modality}_initialisation"

--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -1349,8 +1349,8 @@ class Model:
                                 "ichd",
                                 "hhd",
                                 patient.time_starts_dialysis,
-                                float(self.env.now)
-                                - float(patient.time_starts_dialysis),
+                                np.float64(self.env.now)
+                                - np.float64(patient.time_starts_dialysis),
                             )
                             patient.time_until_death -= np.float64(
                                 self.env.now

--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -53,9 +53,14 @@ class Model:
         self.run_number = run_number
         self.rng = rng
         ## new
-        seeds = rng.integers(0, 2**31, size=5)
+        seeds = rng.integers(0, 2**31, size=10)
         self.arrivals_rng = np.random.default_rng(seeds[0])
         self.interventions_rng = np.random.default_rng(seeds[1])
+        self.deaths_rng = np.random.default_rng(seeds[2])
+        self.waiting_for_live_transplant_rng = np.random.default_rng(seeds[3])
+        self.waiting_for_cadaver_transplant_rng = np.random.default_rng(seeds[4])
+        self.live_graft_failure_rng = np.random.default_rng(seeds[5])
+        self.cadaver_graft_failure_rng = np.random.default_rng(seeds[6])
         ##
         self.patient_types = self.config.mean_iat_over_time_dfs.keys()
         self.patients_in_system: dict = {k: 0 for k in self.patient_types}
@@ -135,7 +140,7 @@ class Model:
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -160,7 +165,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -178,7 +183,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -199,7 +204,7 @@ class Model:
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -216,7 +221,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -246,7 +251,7 @@ class Model:
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -271,7 +276,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -289,7 +294,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -310,7 +315,7 @@ class Model:
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -327,7 +332,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -356,7 +361,7 @@ class Model:
                 ## they aren't suitable for transplant
                 p.transplant_suitable = False
                 p.time_until_death = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["initialisation"]["not_listed"][
                         p.referral_type
                     ][p.age_group]["scale"],
@@ -381,7 +386,7 @@ class Model:
                         self.config.sim_duration + 1
                     )  # they're listed but don't receive a transplant in the simulation period
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["listed"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -399,7 +404,7 @@ class Model:
                     # they do receive a transplant in the simulation period
                     p.transplant_suitable = True
                     p.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                             p.referral_type
                         ][p.age_group]["scale"],
@@ -420,7 +425,7 @@ class Model:
                         # it's a live transplant, but not pre-emptive as they're already on dialysis
                         p.transplant_type = "live"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_live_transplant_rng,
                             scale=self.config.tw_liveTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -437,7 +442,7 @@ class Model:
                     else:
                         p.transplant_type = "cadaver"
                         p.remaining_time_on_transplant_list = calculate_time_to_event(
-                            self.rng,
+                            self.waiting_for_cadaver_transplant_rng,
                             scale=self.config.tw_cadTx["initialisation"][p.age_group][
                                 "scale"
                             ],
@@ -460,7 +465,7 @@ class Model:
             transplant_type = location.split("_")[0]
             p.transplant_suitable = True
             p.time_until_death = calculate_time_to_event(
-                self.rng,
+                self.deaths_rng,
                 scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                     p.referral_type
                 ][p.age_group]["scale"],
@@ -588,7 +593,7 @@ class Model:
             patient.transplant_suitable = False
             if patient.time_until_death == 0:
                 patient.time_until_death = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["incidence"]["not_listed"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -613,7 +618,7 @@ class Model:
                 # Although suitable for transplant, patient does not receive a transplant in the simulation period
                 if patient.time_until_death == 0:
                     patient.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["incidence"]["listed"][
                             patient.referral_type
                         ][patient.age_group]["scale"],
@@ -635,7 +640,7 @@ class Model:
                 # Patient may receive a transplant in the simulation period
                 if patient.time_until_death == 0:
                     patient.time_until_death = calculate_time_to_event(
-                        self.rng,
+                        self.deaths_rng,
                         scale=self.config.ttd_krt["incidence"]["received_Tx"][
                             patient.referral_type
                         ][patient.age_group]["scale"],
@@ -674,7 +679,7 @@ class Model:
                         patient.time_enters_waiting_list = self.env.now
                         patient.remaining_time_on_transplant_list = (
                             calculate_time_to_event(
-                                self.rng,
+                                self.waiting_for_live_transplant_rng,
                                 scale=self.config.tw_liveTx["incidence"][
                                     patient.age_group
                                 ]["scale"],
@@ -719,7 +724,7 @@ class Model:
                         patient.time_enters_waiting_list = self.env.now
                         patient.remaining_time_on_transplant_list = (
                             calculate_time_to_event(
-                                self.rng,
+                                self.waiting_for_cadaver_transplant_rng,
                                 scale=self.config.tw_cadTx["incidence"][
                                     patient.age_group
                                 ]["scale"],
@@ -839,7 +844,7 @@ class Model:
             if patient.patient_flag == "incident":
                 random_number = truncate_2dp(self.rng.uniform(0, 1))
                 sampled_time = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["incidence"]["received_Tx"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -856,7 +861,7 @@ class Model:
             else:  # prevalent patient
                 random_number = truncate_2dp(self.rng.uniform(0, 1))
                 sampled_time = calculate_time_to_event(
-                    self.rng,
+                    self.deaths_rng,
                     scale=self.config.ttd_krt["initialisation"]["received_Tx"][
                         patient.referral_type
                     ][patient.age_group]["scale"],
@@ -877,7 +882,7 @@ class Model:
             # how long the graft lasts depends on where they go next: death or back to start_krt
             ## sampled_wait_time depends on whether patient is incident or not
             if patient.patient_flag == "incident":
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                random_number = truncate_2dp(self.live_graft_failure_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx"].loc[
                         random_number, patient.patient_type
@@ -885,7 +890,7 @@ class Model:
                     * self.config.multipliers["ttgf"]["inc"]["live"]
                 )
             else:  # prevalent patient
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                random_number = truncate_2dp(self.live_graft_failure_rng.uniform(0, 1))
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx_initialisation"].loc[
                         random_number, patient.patient_type
@@ -894,7 +899,9 @@ class Model:
                 )
         else:  # cadaver
             if patient.patient_flag == "incident":
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                random_number = truncate_2dp(
+                    self.cadaver_graft_failure_rng.uniform(0, 1)
+                )
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_cadTx"].loc[
                         random_number, patient.patient_type
@@ -902,7 +909,9 @@ class Model:
                     * self.config.multipliers["ttgf"]["inc"]["cadaver"]
                 )
             else:  # prevalent patient
-                random_number = truncate_2dp(self.rng.uniform(0, 1))
+                random_number = truncate_2dp(
+                    self.cadaver_graft_failure_rng.uniform(0, 1)
+                )
                 sampled_wait_time = (
                     self.config.time_to_event_curves["ttgf_liveTx_initialisation"].loc[
                         random_number, patient.patient_type

--- a/renal_capacity_model/model.py
+++ b/renal_capacity_model/model.py
@@ -52,6 +52,11 @@ class Model:
         self.patient_counter: int = 0
         self.run_number = run_number
         self.rng = rng
+        ## new
+        seeds = rng.integers(0, 2**31, size=5)
+        self.arrivals_rng = np.random.default_rng(seeds[0])
+        self.interventions_rng = np.random.default_rng(seeds[1])
+        ##
         self.patient_types = self.config.mean_iat_over_time_dfs.keys()
         self.patients_in_system: dict = {k: 0 for k in self.patient_types}
         self.patient_objects: list[Patient] = []
@@ -514,7 +519,7 @@ class Model:
             mean_iat = self.config.mean_iat_over_time_dfs[patient_type].loc[
                 year, "mean_iat"
             ]
-            sampled_iat = self.rng.exponential(mean_iat)
+            sampled_iat = self.arrivals_rng.exponential(mean_iat)
             yield self.env.timeout(sampled_iat)
             self.patient_counter += (
                 1  # we use the patient_counter for the ID so this must come first
@@ -1302,10 +1307,6 @@ class Model:
                 )
                 hhd_target = self.config.hhd_intervention_target[which_year]
                 if hhd_proportion < hhd_target:
-                    ## we take from ichd and give to hhd
-                    # ichd_patients = [
-                    #    i for i in self.patient_objects if i.dialysis_modality == "ichd"
-                    # ]
                     ichd_patients = last_entries[
                         (last_entries["activity_from"] == "ichd")
                         & (
@@ -1321,7 +1322,7 @@ class Model:
                     total_patients_to_move = int(
                         hhd_target * total_dialysis_count - hhd_count
                     )  # how many patients do we need to move to hhd to meet the target?
-                    patients_to_move = np.random.choice(
+                    patients_to_move = self.interventions_rng.choice(
                         ichd_patients, size=total_patients_to_move, replace=False
                     )
                     # randomly select patients to move from ichd to hhd
@@ -1332,19 +1333,7 @@ class Model:
                             self.stop_patient(
                                 process=self.processes[patient.id], patient=patient
                             )
-                            ## get rid of the last entry in the log for this patient
-                            # if not self.event_log.loc[
-                            #    self.event_log["patient_id"] == patient.id
-                            # ].empty:
-                            #    if patient.time_starts_dialysis != self.env.now - 364:
-                            # self.event_log = self.event_log.drop(
-                            #    self.event_log.index[
-                            #        (self.event_log["patient_id"] == patient.id)
-                            #    ][-1]
-                            # )
-                            #        pass
-                            ## add new entry in the log for this patient ## we remove the old one at the end of the experiment
-                            self._update_event_log(
+                            self._update_event_log(  ## note that the event log is processed at the end of experiment to remove redundant prior entry that was interrupted
                                 patient,
                                 "ichd",
                                 "hhd",
@@ -1391,19 +1380,24 @@ class Model:
                     total_patients_to_move = -int(
                         hhd_target * total_dialysis_count - hhd_count
                     )  # how many patients do we need to move to hhd to meet the target?
-                    patients_to_move = np.random.choice(
+                    patients_to_move = self.interventions_rng.choice(
                         hhd_patients, size=total_patients_to_move, replace=False
                     )
                     for patient in self.patient_objects:
                         if patient.id in patients_to_move:
-                            patient.dialysis_modality = "ichd"
-
                             # pass in the process we want to interrupt
                             # interrupt the current process for the patient as we are changing their modality outside of the normal modality change process
                             self.stop_patient(
                                 process=self.processes[patient.id], patient=patient
                             )
-
+                            self._update_event_log(  ## note that the event log is processed at the end of experiment to remove redundant prior entry that was interrupted
+                                patient,
+                                "hhd",
+                                "ichd",
+                                patient.time_starts_dialysis,
+                                np.float64(self.env.now)
+                                - np.float64(patient.time_starts_dialysis),
+                            )
                             patient.time_until_death -= np.float64(
                                 self.env.now
                             ) - np.float64(patient.time_starts_dialysis)
@@ -1414,6 +1408,7 @@ class Model:
                                 patient.remaining_time_on_transplant_list -= np.float64(
                                     self.env.now
                                 ) - np.float64(patient.time_starts_dialysis)
+                            patient.dialysis_modality = "ichd"
                             patient.time_starts_dialysis = self.env.now
                             try:
                                 self.processes[patient.id] = self.env.process(


### PR DESCRIPTION
I now log a new event if we're doing a HHD intervention to replace the bit of the log that would have played out before the interruption. 

In the event log processing I then look for duplicate rows in the time_starting_activity_from and remove the first of these as that's the redundant one.